### PR TITLE
Passing self.driver instead of driver

### DIFF
--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -49,7 +49,7 @@ class NapalmBaseAction(Action):
         self.driver = found_device['driver']
         self.htmlout = htmlout
 
-        return get_network_driver(driver)(
+        return get_network_driver(self.driver)(
             hostname=str(found_device['hostname']),
             username=login['username'],
             password=login['password'],


### PR DESCRIPTION
Was passing the optional function argument as driver, instead of `self.driver`, which will always contain the intended driver, taking the configuration into account.

Closes https://github.com/StackStorm-Exchange/stackstorm-napalm/issues/7