### PR TITLE
Implement chatops-enabled configuration consistency checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# OS files
+*.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/README.md
+++ b/README.md
@@ -226,3 +226,16 @@ This pack is actively being developed.
 Most actions put their output under the key raw and when the htmlout option is ticked (see above)
 the output is in 'raw' and 'html'. the cli action also adds a 'raw_array' key to the result so
 you can iterate through the lines as 'raw' contains lines with a newline ending.
+
+### Developing the NAPALM Pack
+
+If you're copying or rsyncing files directly into a VM, bypassing the normal pack installation process
+(which is normal during development) then you'll want to be aware of a few things.
+
+First, you'll need to install the virtualenv yourself:
+
+  st2 run packs.setup_virtualenv packs=napalm
+
+Also, you will need to manually register the pack if you make changes to its metadata or configuration:
+
+  st2 pack register napalm

--- a/actions/check_consistency.meta.yaml
+++ b/actions/check_consistency.meta.yaml
@@ -1,0 +1,37 @@
+---
+name: "check_consistency"
+runner_type: "python-script"
+description: "Check that the device's configuration is consistent with the 'golden' config in a Git repository"
+enabled: true
+entry_point: "check_consistency.py"
+parameters:
+    hostname:
+        type: "string"
+        description: "The hostname of the device to connect to. Driver must be specified if hostname is not in configuration. Hostname without FQDN can be given if device is in configuration."
+        required: true
+        position: 0
+    driver:
+        type: "string"
+        description: "Device driver name for connecting to device, see https://napalm.readthedocs.io/en/latest/support/index.html for list."
+        required: false
+        position: 1
+    port:
+        type: "string"
+        description: "port for accessing device"
+        required: false
+        position: 2
+    credentials:
+        type: "string"
+        description: "The credentials group which contains the username and password to log in"
+        required: false
+        position: 3
+    htmlout:
+        type: "boolean"
+        description: "In addition to the normal output also includes html output."
+        required: false
+        position: 4
+    repository:
+        type: "string"
+        description: "Git repository where the 'golden' device configurations are stored"
+        required: false
+        position: 5

--- a/actions/check_consistency.meta.yaml
+++ b/actions/check_consistency.meta.yaml
@@ -32,6 +32,6 @@ parameters:
         position: 4
     repository:
         type: "string"
-        description: "Git repository where the 'golden' device configurations are stored"
+        description: "Git repository where the 'golden' device configurations are stored (overrides configuration)"
         required: false
         position: 5

--- a/actions/check_consistency.py
+++ b/actions/check_consistency.py
@@ -1,11 +1,20 @@
 import difflib
+import logging
 import os
+import re
 import shutil
 import tempfile
 
 from lib.action import NapalmBaseAction
 
 import git
+
+# Suppressing the 'No handlers could be found for logger "st2.st2common.util.loader"' message
+# that appears when including the TempRepo class, until I have a chance to troubleshoot why
+# this is happening TODO(mierdin)
+loaderlog = logging.getLogger('st2.st2common.util.loader')
+loaderlog.setLevel(logging.DEBUG)
+loaderlog.addHandler(logging.NullHandler())
 
 
 class TempRepo(object):
@@ -25,10 +34,16 @@ class NapalmCheckConsistency(NapalmBaseAction):
 
         with TempRepo() as tmpdir:
             repo_path = os.path.join(tmpdir, 'repo')
-            repo = git.Repo.clone_from(repo, repo_path, branch='master')
-            with open('%s/%s.txt' % (repo_path, device)) as config_file:
-                return "".join(config_file.readlines())
+            git.Repo.clone_from(repo, repo_path, branch='master')
 
+            try:
+
+                with open('%s/%s.txt' % (repo_path, device)) as config_file:
+                    return "".join(config_file.readlines())
+
+            except IOError:
+                self.logger.error("Golden config not present in repo")
+                raise
 
     def run(self, repository=None, **std_kwargs):
 
@@ -52,10 +67,23 @@ class NapalmCheckConsistency(NapalmBaseAction):
                 golden_config = self.get_golden_config(repository, self.hostname)
                 actual_config = device.get_config()['running']
 
+                # Regular expressions for matching lines to ignore
+                # Lot of network devices have lines like "last modified" that we don't
+                # want to include in the diff
+                #
+                # In the future, this may be a configurable option, but we're doing
+                # this statically for now.
+                ignore_regexs = [
+                    "## .*\n"
+                ]
+                for pattern in ignore_regexs:
+                    actual_config = re.sub(pattern, "", actual_config)
+                    golden_config = re.sub(pattern, "", golden_config)
+
                 # Generate diff
-                golden=golden_config.splitlines(1)
-                actual=actual_config.splitlines(1)
-                diff=difflib.unified_diff(golden, actual)
+                golden = golden_config.splitlines(1)
+                actual = actual_config.splitlines(1)
+                diff = difflib.unified_diff(golden, actual)
                 diff = ''.join(diff)
 
                 if diff:

--- a/actions/check_consistency.py
+++ b/actions/check_consistency.py
@@ -30,7 +30,14 @@ class NapalmCheckConsistency(NapalmBaseAction):
                 return "".join(config_file.readlines())
 
 
-    def run(self, repository, **std_kwargs):
+    def run(self, repository=None, **std_kwargs):
+
+        if not self.config['config_repo'] and not repository:
+            raise Exception("Golden configs repository not provided in args or config")
+        else:
+            # Use config if arg not provided
+            if not repository:
+                repository = self.config['config_repo']
 
         result = {
             "deviation": False,
@@ -49,6 +56,7 @@ class NapalmCheckConsistency(NapalmBaseAction):
                 golden=golden_config.splitlines(1)
                 actual=actual_config.splitlines(1)
                 diff=difflib.unified_diff(golden, actual)
+                diff = ''.join(diff)
 
                 if diff:
                     result['deviation'] = True

--- a/actions/check_consistency.py
+++ b/actions/check_consistency.py
@@ -42,7 +42,7 @@ class NapalmCheckConsistency(NapalmBaseAction):
                     return "".join(config_file.readlines())
 
             except IOError:
-                self.logger.error("Golden config not present in repo")
+                self.logger.error("Golden config not present in repo: %s" % repo)
                 raise
 
     def run(self, repository=None, **std_kwargs):

--- a/actions/check_consistency.py
+++ b/actions/check_consistency.py
@@ -1,0 +1,61 @@
+import difflib
+import os
+import shutil
+import tempfile
+
+from lib.action import NapalmBaseAction
+
+import git
+
+
+class TempRepo(object):
+    def __enter__(self):
+        self.name = tempfile.mkdtemp()
+        return self.name
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        shutil.rmtree(self.name)
+
+
+class NapalmCheckConsistency(NapalmBaseAction):
+    """Check that the device's configuration is consistent with the 'golden' config in a Git repository
+    """
+
+    def get_golden_config(self, repo, device):
+
+        with TempRepo() as tmpdir:
+            repo_path = os.path.join(tmpdir, 'repo')
+            repo = git.Repo.clone_from(repo, repo_path, branch='master')
+            with open('%s/%s.txt' % (repo_path, device)) as config_file:
+                return "".join(config_file.readlines())
+
+
+    def run(self, repository, **std_kwargs):
+
+        result = {
+            "deviation": False,
+            "diff_contents": ""
+        }
+
+        try:
+
+            with self.get_driver(**std_kwargs) as device:
+
+                # Get golden and actual configs
+                golden_config = self.get_golden_config(repository, self.hostname)
+                actual_config = device.get_config()['running']
+
+                # Generate diff
+                golden=golden_config.splitlines(1)
+                actual=actual_config.splitlines(1)
+                diff=difflib.unified_diff(golden, actual)
+
+                if diff:
+                    result['deviation'] = True
+                    result['diff_contents'] = ''.join(diff)
+
+        except Exception, e:
+            self.logger.error(str(e))
+            return (False, str(e))
+
+        return (True, result)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -113,8 +113,8 @@ class NapalmBaseAction(Action):
         # we fail.
 
         if not driver:
-            raise ValueError('Can not find driver for host {}, try with \
-                            driver parameter.'.format(host_result))
+            raise ValueError('Can not find driver for host {}, try with '
+                             'driver parameter.'.format(host_result))
 
         if not credentials:
             raise ValueError(('Can not find credential group for host {}, try with credentials'

--- a/aliases/check_consistency.yaml
+++ b/aliases/check_consistency.yaml
@@ -4,5 +4,17 @@ pack: "napalm"
 action_ref: "napalm.check_consistency"
 description: "Check consistency of the device's configuration"
 formats:
-  - "check consistency on {{hostname}}"
+  - "napalm check consistency on {{hostname}}"
   # - "check consistency on all"  #TODO(mierdin): Won't work until actions can iterate over device list
+
+result:
+  format: |
+    {% if execution.result.result.deviation %}
+      The configuration on {{ execution.parameters.hostname }} has deviated from the golden configuration.
+
+      Diff to follow:
+        {{ execution.result.result.diff_contents }}
+
+    {% else %}
+      The configuration on {{ execution.parameters.hostname }} exactly matches the golden configuration.
+    {% endif %}

--- a/aliases/check_consistency.yaml
+++ b/aliases/check_consistency.yaml
@@ -1,0 +1,8 @@
+---
+name: "check_consistency"
+pack: "napalm"
+action_ref: "napalm.check_consistency"
+description: "Check consistency of the device's configuration"
+formats:
+  - "check consistency on {{hostname}}"
+  # - "check consistency on all"  #TODO(mierdin): Won't work until actions can iterate over device list

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -4,6 +4,11 @@ html_table_class:
   type: "string"
   required: true
 
+config_repo:
+  description: "Git repository where configurations are located"
+  type: "string"
+  required: false
+
 devices:
   description: "List of devices to map the device hostname with the driver and credentials"
   required: true

--- a/napalm.yaml.example
+++ b/napalm.yaml.example
@@ -1,5 +1,6 @@
 ---
 html_table_class: napalm
+config_repo: https://github.com/StackStorm/vsrx-configs.git
 
 credentials:
   core:

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - juniper
     - arista
     - ibm
-version: 0.2.1
+version: 0.2.2
 author: mierdin, Rob Woodward
 email: info@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ napalm-pluribus
 napalm-panos
 napalm
 json2table
+GitPython


### PR DESCRIPTION
This PR provides an action, and accompanying action-aliase for performing automated WIRI (what it really is) vs WISB (what it should be) comparisons.

Here's an example:

```
vagrant@st2vagrant:~$ st2 run napalm.check_consistency hostname=vsrx01
..
id: 58ebd2b6c4da5f05575d9b8d
status: succeeded
parameters:
  hostname: vsrx01
result:
  exit_code: 0
  result:
    deviation: true
    diff_contents: "---
+++
@@ -72,6 +72,7 @@
         unit 0 {
             family inet {
                 address 192.168.50.51/24;
+                address 192.168.50.50/24;
             }
         }
     }
"
  stderr: ''
  stdout: ''
```

Also some misc corrections/cleanups.