### PR TITLE
Fix issue with the webhooks

### DIFF
--- a/rules/bgp_prefix_exceeded.yaml
+++ b/rules/bgp_prefix_exceeded.yaml
@@ -1,5 +1,6 @@
 ---
   name: "bgp_prefix_exceeded"
+  pack: "napalm"
   enabled: true
   description: "Webhook which handles a BGP neighbour exceeding it's prefix limit"
 
@@ -14,7 +15,6 @@
     ref: napalm.bgp_prefix_exceeded_chain
     parameters:
       hostname: "{{trigger.body.logsource}}"
-      host_ip: "{{trigger.body.host}}"
       message: "{{trigger.body.message}}"
       neighbour: "{{trigger.body.neighbour}}"
       asnum: "{{trigger.body.asnum}}"

--- a/rules/configuration_change.yaml
+++ b/rules/configuration_change.yaml
@@ -1,5 +1,6 @@
 ---
   name: "configuration_change"
+  pack: "napalm"
   enabled: true
   description: "Webhook which handles when a device has been configured and changes commited"
 
@@ -14,7 +15,6 @@
     ref: napalm.configuration_change_workflow
     parameters:
       hostname: "{{trigger.body.logsource}}"
-      host_ip: "{{trigger.body.host}}"
       driver: "{{trigger.body.os_type}}"
       message: "{{trigger.body.message}}"
       username: "{{trigger.body.username}}"

--- a/rules/interface_down.yaml
+++ b/rules/interface_down.yaml
@@ -1,5 +1,6 @@
 ---
   name: "interface_down"
+  pack: "napalm"
   enabled: true
   description: "Webhook which handles an interface going down on a network device."
 
@@ -14,6 +15,5 @@
     ref: napalm.interface_down_workflow
     parameters:
       hostname: "{{trigger.body.logsource}}"
-      host_ip: "{{trigger.body.host}}"
       message: "{{trigger.body.message}}"
       interface: "{{trigger.body.interface}}"


### PR DESCRIPTION
Removed unnecessary parameter from the rules files (bgp_prefix_exceeded, configuration_change and interface_down).
All of them had "host_ip" being listed as a parameter of the resulting action. While that action does not contain that "host_ip".
