### PR TITLE
Fix typos in BGP actions which prevented usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,16 +112,16 @@ Actions in the NAPALM pack largely mirror the NAPALM library methods documented
 [here](https://napalm.readthedocs.io/en/latest/base.html).
 
 - **cli**: Run a CLI command on a devices.
-- **get_arp_table**:  Get the APR table from a device.
+- **get_arp_table**:  Get the ARP table from a device.
 - **get_bgp_config**: Get BGP configuration from a device.
-- **get_bgp_neighbors**: Get the BGP Neighbours from a device.
-- **get_bgp_neighbors_detail**: Get a detailed BGP neighbour from a device.
+- **get_bgp_neighbors**: Get the BGP Neighbors from a device.
+- **get_bgp_neighbors_detail**: Get a detailed BGP neighbor from a device.
 - **get_config**: Get configuration from the device.
 - **get_environment**: Get the environment sensor output from a device.
 - **get_facts**: Get the various facts (Version, Serial Number, Vendor, Model, etc.) from a device.
 - **get_firewall_policies**: Get firewall policies from a device.
 - **get_interfaces**: Get interfaces from a device.
-- **get_lldp_neighbors**: Get the LLDP Neighbours from a device.
+- **get_lldp_neighbors**: Get the LLDP Neighbors from a device.
 - **get_log**: Get logs from devices.
 - **get_mac_address_table**: Get the MAC Address table from a device.
 - **get_network_instances**: Get details of network/routing instances/vrfs from a device.
@@ -148,7 +148,7 @@ on this.
 
 - **configuration_change_workflow**: Webhook trigger to run a remote backup mistral workflow when a configuration change is detected on a device.
 - **interface_down_chain**: Webhook trigger to run an action chain when an interface goes down.
-- **bgp_prefix_exceeded_chain**: Webhook trigger to run an action chain when a bgp neighbour exceeds its prefix limit.
+- **bgp_prefix_exceeded_chain**: Webhook trigger to run an action chain when a bgp neighbor exceeds its prefix limit.
 
 ## Datastore
 

--- a/actions/bgp_prefix_exceeded_chain.yaml
+++ b/actions/bgp_prefix_exceeded_chain.yaml
@@ -1,6 +1,6 @@
 ---
   name: "bgp_prefix_exceeded_chain"
-  description: "Action Chain to process a BGP neighbour prefix limit exceeded event."
+  description: "Action Chain to process a BGP neighbor prefix limit exceeded event."
   runner_type: "action-chain"
   pack: napalm
   enabled: true
@@ -14,15 +14,15 @@
       required: true
       description: "Syslog Message"
       type: string
-    neighbour:
+    neighbor:
       required: true
-      description: "IP Address of the neighbour that has gone down."
+      description: "IP Address of the neighbor that has gone down."
       type: string
     asnum:
       required: true
-      description: "AS Number of the neighbour that has gone down"
+      description: "AS Number of the neighbor that has gone down"
       type: string
     prefixes:
       required: true
-      description: "Number of prefixes the neighbour is sending"
+      description: "Number of prefixes the neighbor is sending"
       type: integer

--- a/actions/chains/bgp_prefix_exceeded_chain.yaml
+++ b/actions/chains/bgp_prefix_exceeded_chain.yaml
@@ -5,7 +5,7 @@
         ref: "napalm.get_bgp_neighbors"
         parameters:
           hostname: "{{ hostname }}"
-          neighbour: "{{ neighbour }}"
+          neighbor: "{{ neighbor }}"
           htmlout: true
         on-success: "show_route"
         on-failure: "report_failure"
@@ -14,7 +14,7 @@
         ref: "napalm.get_route_to"
         parameters:
           hostname: "{{ hostname }}"
-          destination: "{{ neighbour }}"
+          destination: "{{ neighbor }}"
           htmlout: true
         on-success: "show_log"
         on-failure: "report_failure"
@@ -49,12 +49,12 @@
         parameters:
           to: "{{st2kv.system.napalm_bgpsyslog_mailto}}"
           from: "{{st2kv.system.napalm_bgpsyslog_mailfrom}}"
-          subject: "BGP neighbour {{ neighbour }} AS{{ asnum }} exceeded prefix limit on {{ hostname }}."
+          subject: "BGP neighbor {{ neighbor }} AS{{ asnum }} exceeded prefix limit on {{ hostname }}."
           content_type: "text/html"
           body: "{{ html_header }}
                 <p>The following syslog triggered this event: {{ message }}</p>
-                <h2>BGP Neighbour Details</h2>
-                {{ show_bgp_neighbours.result.html }}<br />
+                <h2>BGP Neighbor Details</h2>
+                {{ show_bgp_neighbors.result.html }}<br />
                 <h2>Route to BGP Peer Address</h2>
                 {{ show_route.result.html }}<br />
                 <h2>Last 10 log lines on Device</h2>
@@ -69,4 +69,4 @@
           from: "{{st2kv.system.napalm_actionerror_mailfrom}}"
           subject: "Stackstorm BGP prefix exceeded workflow error"
           body:  "Something went wrong with the BGP prefix exceeded workflow. Check stackstorm for the error. Execution ID: {{action_context.parent.execution_id}}.\r\n\r\n"
-  default: "show_bgp_neighbours"
+  default: "show_bgp_neighbors"

--- a/actions/get_bgp_config.py
+++ b/actions/get_bgp_config.py
@@ -5,21 +5,21 @@ class NapalmGetBGPConfig(NapalmBaseAction):
     """Get BGP configuration from a network device via NAPALM
     """
 
-    def run(self, group, neighbour, **std_kwargs):
+    def run(self, group, neighbor, **std_kwargs):
 
         try:
             with self.get_driver(**std_kwargs) as device:
 
                 if not group:
-                    if not neighbour:
+                    if not neighbor:
                         bgpconf = device.get_bgp_config()
                     else:
-                        bgpconf = device.get_bgp_config(neighbor=neighbour)
+                        bgpconf = device.get_bgp_config(neighbor=neighbor)
                 else:
-                    if not neighbour:
+                    if not neighbor:
                         bgpconf = device.get_bgp_config(group=group)
                     else:
-                        bgpconf = device.get_bgp_config(group=group, neighbor=neighbour)
+                        bgpconf = device.get_bgp_config(group=group, neighbor=neighbor)
 
                 result = {'raw': bgpconf}
 

--- a/actions/get_bgp_config.yaml
+++ b/actions/get_bgp_config.yaml
@@ -5,7 +5,6 @@ description: "Get BGP configuration from a device using NAPALM."
 enabled: true
 entry_point: "get_bgp_config.py"
 parameters:
-parameters:
     hostname:
         type: "string"
         description: "The hostname of the device to connect to. Driver must be specified if hostname is not in configuration. Hostname without FQDN can be given if device is in configuration."

--- a/actions/get_bgp_neighbors_detail.yaml
+++ b/actions/get_bgp_neighbors_detail.yaml
@@ -3,7 +3,7 @@ name: "get_bgp_neighbors_detail"
 runner_type: "python-script"
 description: "Get a detailed BGP neighbor from a device using NAPALM."
 enabled: true
-entry_point: "get_bgp_neighbors.py"
+entry_point: "get_bgp_neighbors_detail.py"
 parameters:
     hostname:
         type: "string"

--- a/actions/get_lldp_neighbors.py
+++ b/actions/get_lldp_neighbors.py
@@ -1,8 +1,8 @@
 from lib.action import NapalmBaseAction
 
 
-class NapalmGetLLDPNeighbours(NapalmBaseAction):
-    """Get LLDP neighbours from a network device via NAPALM
+class NapalmGetLLDPNeighbors(NapalmBaseAction):
+    """Get LLDP neighbors from a network device via NAPALM
     """
 
     def run(self, interface, **std_kwargs):
@@ -11,15 +11,15 @@ class NapalmGetLLDPNeighbours(NapalmBaseAction):
             with self.get_driver(**std_kwargs) as device:
 
                 if not interface:
-                    lldp_neighbours = {'raw': device.get_lldp_neighbors()}
+                    lldp_neighbors = {'raw': device.get_lldp_neighbors()}
                 else:
-                    lldp_neighbours = {'raw': device.get_lldp_neighbors_detail(interface)}
+                    lldp_neighbors = {'raw': device.get_lldp_neighbors_detail(interface)}
 
                 if self.htmlout:
-                    lldp_neighbours['html'] = self.html_out(lldp_neighbours['raw'])
+                    lldp_neighbors['html'] = self.html_out(lldp_neighbors['raw'])
 
         except Exception, e:
             self.logger.error(str(e))
             return (False, str(e))
 
-        return (True, lldp_neighbours)
+        return (True, lldp_neighbors)

--- a/actions/get_lldp_neighbors.yaml
+++ b/actions/get_lldp_neighbors.yaml
@@ -1,7 +1,7 @@
 ---
 name: "get_lldp_neighbors"
 runner_type: "python-script"
-description: "Get the LLDP Neighbours from a device using NAPALM."
+description: "Get the LLDP Neighbors from a device using NAPALM."
 enabled: true
 entry_point: "get_lldp_neighbors.py"
 parameters:

--- a/actions/workflows/check_consistency_chatops.yaml
+++ b/actions/workflows/check_consistency_chatops.yaml
@@ -1,0 +1,71 @@
+---
+  version: '2.0'
+
+  # TODO(mierdin): Might have to convert this to an actionchain, as per-task notifications is not yet supported in mistral
+
+
+  napalm.check_consistency_chatops:
+
+    input:
+      - hostname
+      - driver
+
+    type: direct
+
+    task-defaults:
+      on-error:
+        - notify_on_error
+
+    tasks:
+      send_detected_email:
+        action: core.sendmail
+        input:
+          to: "<% st2kv('system.napalm_remotebackup_mailto') %>"
+          from: "<% st2kv('system.napalm_remotebackup_mailfrom') %>"
+          # Will work when this is in the code: https://github.com/StackStorm/st2/pull/3177
+          #subject: "Stackstorm detected a configuration change on <% $.hostname %> {% if _.username %} by {{ _.username }} {% endif %}."
+          subject: "Stackstorm detected a configuration change on <% $.hostname %> by <% $.username %>."
+          content_type: "text/plain"
+          body: "\r\n\r\nThe following syslog triggered this event: <% $.message %>\r\n\r\n"
+        on-success:
+          - backup_device
+
+      backup_device:
+        action: "core.remote"
+        wait-before: 60
+        input:
+          cmd: "<% st2kv('system.napalm_remotebackup_cmd') %> <% $.hostname %> <% $.driver %>"
+          username: "<% st2kv('system.napalm_remotebackup_user') %>"
+          private_key: "/home/stanley/.ssh/stanley_rsa"
+          hosts: "<% st2kv('system.napalm_remotebackup_host') %>"
+        publish:
+          stdout: <% task(backup_device).result.get(st2kv('system.napalm_remotebackup_host')).stdout %>
+          stderr: <% task(backup_device).result.get(st2kv('system.napalm_remotebackup_host')).stderr %>
+        on-success:
+          - send_complete_email
+
+      send_complete_email:
+        action: core.sendmail
+        input:
+          to: "<% st2kv('system.napalm_remotebackup_mailto') %>"
+          from: "<% st2kv('system.napalm_remotebackup_mailfrom') %>"
+          subject: "Stackstorm completed a backup of <% $.hostname %>."
+          content_type: "text/plain"
+          body: "\r\nThe following syslog triggered this event: <% $.message %>\r\n\r\n
+                \r\n<% $.stderr %>\r\n
+                \r\n<% $.stdout %>\r\n
+                \r\n\r\n"
+
+      # notify_consistent:
+
+      # notify_inconsistent:
+
+      notify_on_error:
+        action: core.sendmail
+        input:
+          to: "<% st2kv('system.napalm_actionerror_mailto') %>"
+          from: "<% st2kv('system.napalm_actionerror_mailfrom') %>"
+          subject: "Stackstorm device backup workflow error"
+          body:  "Something went wrong with the device backup workflow. Check stackstorm for the error. Execution ID <% env().st2_execution_id %>\r\n\r\n"
+        on-complete:
+          - fail

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - juniper
     - arista
     - ibm
-version: 0.2.2
+version: 0.2.3
 author: mierdin, Rob Woodward
 email: info@stackstorm.com

--- a/rules/bgp_prefix_exceeded.yaml
+++ b/rules/bgp_prefix_exceeded.yaml
@@ -1,7 +1,7 @@
 ---
   name: "bgp_prefix_exceeded"
   enabled: true
-  description: "Webhook which handles a BGP neighbour exceeding it's prefix limit"
+  description: "Webhook which handles a BGP neighbor exceeding it's prefix limit"
 
   trigger:
     type: "core.st2.webhook"
@@ -16,6 +16,6 @@
       hostname: "{{trigger.body.logsource}}"
       host_ip: "{{trigger.body.host}}"
       message: "{{trigger.body.message}}"
-      neighbour: "{{trigger.body.neighbour}}"
+      neighbor: "{{trigger.body.neighbor}}"
       asnum: "{{trigger.body.asnum}}"
       prefixes: "{{trigger.body.prefixes}}"


### PR DESCRIPTION
#14 and #15 reported some issues with using some actions due to parameter issues.

The problem in #14 was caused by the metadata file for `get_bgp_neighbor_detail` mistakenly referring to `get_bgp_neighbor.py` as its entry point instead of the correct one: `get_bgp_neighbor_detail.py`.

The problem in #15 was caused by the metadata referencing the "neighbor" parameter, yet the underlying Python script expected "neighbour". This resulted in the "neighbor" parameter going to `**kw_args`, and `neighbour` remaining unset.

This PR addresses both, as well as adds commits for fixing all other instances of "neighbour" to ensure at least this issue doesn't happen again.

Closes #14 and #15