### PR TITLE
Add example LLDP neighbor count sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,14 @@ Actions in the NAPALM pack largely mirror the NAPALM library methods documented
 - **loadconfig**: Loads (merge) a configuration to a device.
 - **traceroute**: Run a traceroute from a device.
 
+## Sensors
+
+There is one Sensor currently implemented by this pack:
+
+- **napalm.NapalmLLDPSensor**: Detect changes in the number of active LLDP neighbors
+
+> **NOTE** these are here for illustrative purposes only. To ensure production-quality detection of network events, you should integrate StackStorm with your existing monitoring tools.
+
 ## Rules and Triggers
 
 The pack defines rules for handing syslog events or monitoring events. Logstash

--- a/rules/remediate_lldp_neighbor.yaml
+++ b/rules/remediate_lldp_neighbor.yaml
@@ -5,7 +5,7 @@
   description: "Demonstrate simple auto-remediation event"
 
   trigger:
-    type: "napalm.NeighborDecrease"
+    type: "napalm.LLDPNeighborDecrease"
     parameters: {}
 
   criteria: {}

--- a/rules/remediate_lldp_neighbor.yaml
+++ b/rules/remediate_lldp_neighbor.yaml
@@ -1,0 +1,17 @@
+---
+  name: "lldp_remediate"
+  pack: "napalm"
+  enabled: true
+  description: "Demonstrate simple auto-remediation event"
+
+  trigger:
+    type: "napalm.NeighborDecrease"
+    parameters: {}
+
+  criteria: {}
+
+  action:
+    ref: napalm.loadconfig
+    parameters:
+      hostname: juniper1.twb-tech.com
+      config_file: /vagrant/remediation_config.txt

--- a/rules/remediate_lldp_neighbor.yaml
+++ b/rules/remediate_lldp_neighbor.yaml
@@ -13,5 +13,5 @@
   action:
     ref: napalm.loadconfig
     parameters:
-      hostname: juniper1.twb-tech.com
+      hostname: vsrx01
       config_file: /vagrant/remediation_config.txt

--- a/sensors/lldp_sensor.py
+++ b/sensors/lldp_sensor.py
@@ -34,7 +34,7 @@ class NapalmLLDPSensor(PollingSensor):
                 optional_args={
                     # TODO(mierdin): This is obviously not desirable. However, fixing this would
                     # also require fixing the way Actions get their port configuration,
-                    # so I'm leaving this here for now.
+                    # so I'm leaving this here for now, and will fix in a separate PR
                     'port': "22"
                 })
             for device in self._config['devices']

--- a/sensors/lldp_sensor.py
+++ b/sensors/lldp_sensor.py
@@ -21,44 +21,12 @@ class NapalmLLDPSensor(PollingSensor):
         # self._poll_interval = 30
 
     def setup(self):
-        # Need to get initial BGP RIB, neighbor table, etc. Put into "self".
-        # Then, write some logic within "poll" that checks again, and
-        # detects diffs
-        # Detects:
-        # - Diffs in BGP RIB (need to give a threshold like 100s or 1000s or
-        #   routes different)
-        #   (may want to not only store the previous result, but also the
-        #    previous 10 or so and do a stddev calc)
-
-        # Stores number of BGP neighbors
-        # self.bgp_neighbors = 0
-
-        # Stores RIB information in-between calls
-        # self.bgp_rib = {}
-
         # Dictionary for tracking per-device known state
         # Top-level keys are the management IPs sent to NAPALM, and
         # information on each is contained below that
         self.device_state = {}
 
         napalm_config = self._config
-
-        # Assign sane defaults for configuration
-        # default_opts = {
-        #     "opt1": "val1"
-        # }
-        # for opt_name, opt_val in default_opts.items():
-
-        #     try:
-
-        #         # key exists but is set to nothing
-        #         if not napalm_config[opt_name]:
-        #             napalm_config[opt_name] == default_opts
-
-        #     except KeyError:
-
-        #         # key doesn't exist
-        #         napalm_config[opt_name] == default_opts
 
         # Assign options to instance
         self._devices = napalm_config['devices']
@@ -68,8 +36,8 @@ class NapalmLLDPSensor(PollingSensor):
         self.devices = {
             str(device['hostname']): get_network_driver(device['driver'])(
                 hostname=str(device['hostname']),
-                username="interop",
-                password="netauto42",
+                username="root",   # TODO(mierdin): Obviously not desirable. Retrieve from config
+                password="Juniper",
                 optional_args={
                     'port': "22"
                 })
@@ -95,7 +63,7 @@ class NapalmLLDPSensor(PollingSensor):
                     "Peer count went UP to %s" % str(this_lldp_neighbors)
                 )
                 self._lldp_peer_trigger(NEIGHBOR_INCREASE, hostname,
-                                       last_lldp_neighbors, this_lldp_neighbors)
+                                        last_lldp_neighbors, this_lldp_neighbors)
 
             elif this_lldp_neighbors < last_lldp_neighbors:
                 self._logger.info(
@@ -103,7 +71,7 @@ class NapalmLLDPSensor(PollingSensor):
                 )
 
                 self._lldp_peer_trigger(NEIGHBOR_DECREASE, hostname,
-                                       last_lldp_neighbors, this_lldp_neighbors)
+                                        last_lldp_neighbors, this_lldp_neighbors)
 
             elif this_lldp_neighbors == last_lldp_neighbors:
                 self._logger.info(
@@ -148,7 +116,6 @@ class NapalmLLDPSensor(PollingSensor):
         return this_lldp_neighbors
 
     def _lldp_peer_trigger(self, trigger, hostname, oldpeers, newpeers):
-        # trigger = 'napalm.BgpPeerDecrease'
         payload = {
             'device': hostname,
             'oldpeers': int(oldpeers),

--- a/sensors/lldp_sensor.py
+++ b/sensors/lldp_sensor.py
@@ -1,0 +1,159 @@
+from datetime import datetime
+
+from napalm import get_network_driver
+
+from st2reactor.sensor.base import PollingSensor
+
+NEIGHBOR_INCREASE = 'napalm.NeighborIncrease'
+NEIGHBOR_DECREASE = 'napalm.NeighborDecrease'
+
+
+class NapalmLLDPSensor(PollingSensor):
+
+    def __init__(self, sensor_service, config=None, poll_interval=5):
+        super(NapalmLLDPSensor, self).__init__(sensor_service=sensor_service,
+                                               config=config,
+                                               poll_interval=poll_interval)
+        self._logger = self.sensor_service.get_logger(
+            name=self.__class__.__name__
+        )
+
+        # self._poll_interval = 30
+
+    def setup(self):
+        # Need to get initial BGP RIB, neighbor table, etc. Put into "self".
+        # Then, write some logic within "poll" that checks again, and
+        # detects diffs
+        # Detects:
+        # - Diffs in BGP RIB (need to give a threshold like 100s or 1000s or
+        #   routes different)
+        #   (may want to not only store the previous result, but also the
+        #    previous 10 or so and do a stddev calc)
+
+        # Stores number of BGP neighbors
+        # self.bgp_neighbors = 0
+
+        # Stores RIB information in-between calls
+        # self.bgp_rib = {}
+
+        # Dictionary for tracking per-device known state
+        # Top-level keys are the management IPs sent to NAPALM, and
+        # information on each is contained below that
+        self.device_state = {}
+
+        napalm_config = self._config
+
+        # Assign sane defaults for configuration
+        # default_opts = {
+        #     "opt1": "val1"
+        # }
+        # for opt_name, opt_val in default_opts.items():
+
+        #     try:
+
+        #         # key exists but is set to nothing
+        #         if not napalm_config[opt_name]:
+        #             napalm_config[opt_name] == default_opts
+
+        #     except KeyError:
+
+        #         # key doesn't exist
+        #         napalm_config[opt_name] == default_opts
+
+        # Assign options to instance
+        self._devices = napalm_config['devices']
+
+        # Generate dictionary of device objects per configuration
+        # IP Address(key): Device Object(value)
+        self.devices = {
+            str(device['hostname']): get_network_driver(device['driver'])(
+                hostname=str(device['hostname']),
+                username="interop",
+                password="netauto42",
+                optional_args={
+                    'port': "22"
+                })
+            for device in self._devices
+        }
+
+    def poll(self):
+
+        for hostname, device_obj in self.devices.items():
+
+            try:
+                last_lldp_neighbors = self.device_state[hostname]["last_lldp_neighbors"]
+            except KeyError:
+                self.device_state[hostname] = {
+                    "last_lldp_neighbors": self.get_number_of_neighbors(device_obj)
+                }
+                continue
+
+            this_lldp_neighbors = self.get_number_of_neighbors(device_obj)
+
+            if this_lldp_neighbors > last_lldp_neighbors:
+                self._logger.info(
+                    "Peer count went UP to %s" % str(this_lldp_neighbors)
+                )
+                self._lldp_peer_trigger(NEIGHBOR_INCREASE, hostname,
+                                       last_lldp_neighbors, this_lldp_neighbors)
+
+            elif this_lldp_neighbors < last_lldp_neighbors:
+                self._logger.info(
+                    "LLDP neighbors went DOWN to %s" % str(this_lldp_neighbors)
+                )
+
+                self._lldp_peer_trigger(NEIGHBOR_DECREASE, hostname,
+                                       last_lldp_neighbors, this_lldp_neighbors)
+
+            elif this_lldp_neighbors == last_lldp_neighbors:
+                self._logger.info(
+                    "LLDP neighbors STAYED at %s" % str(this_lldp_neighbors)
+                )
+
+            # Save this state for the next poll
+            self.device_state[hostname]["last_lldp_neighbors"] = this_lldp_neighbors
+
+    def cleanup(self):
+        # This is called when the st2 system goes down. You can perform
+        # cleanup operations like closing the connections to external
+        # system here.
+        pass
+
+    def add_trigger(self, trigger):
+        # This method is called when trigger is created
+        pass
+
+    def update_trigger(self, trigger):
+        # This method is called when trigger is updated
+        pass
+
+    def remove_trigger(self, trigger):
+        # This method is called when trigger is deleted
+        pass
+
+    def get_number_of_neighbors(self, device_obj):
+
+        # Retrieve LLDP info
+        try:
+            with device_obj:
+                neighbor_info = device_obj.get_lldp_neighbors()
+        except Exception:  # TODO(mierdin): convert to ConnectionException
+            raise
+
+        this_lldp_neighbors = 0
+
+        for interface, neighbors in neighbor_info.items():
+            this_lldp_neighbors += len(neighbors)
+
+        return this_lldp_neighbors
+
+    def _lldp_peer_trigger(self, trigger, hostname, oldpeers, newpeers):
+        # trigger = 'napalm.BgpPeerDecrease'
+        payload = {
+            'device': hostname,
+            'oldpeers': int(oldpeers),
+            'newpeers': int(newpeers),
+            'timestamp': str(datetime.now()),
+        }
+        self._logger.debug("DISPATCHING TRIGGER %s" % trigger)
+        self._sensor_service.dispatch(trigger=trigger, payload=payload)

--- a/sensors/lldp_sensor.py
+++ b/sensors/lldp_sensor.py
@@ -4,8 +4,8 @@ from napalm import get_network_driver
 
 from st2reactor.sensor.base import PollingSensor
 
-NEIGHBOR_INCREASE = 'napalm.NeighborIncrease'
-NEIGHBOR_DECREASE = 'napalm.NeighborDecrease'
+NEIGHBOR_INCREASE = 'napalm.LLDPNeighborIncrease'
+NEIGHBOR_DECREASE = 'napalm.LLDPNeighborDecrease'
 
 
 class NapalmLLDPSensor(PollingSensor):

--- a/sensors/lldp_sensor.py
+++ b/sensors/lldp_sensor.py
@@ -60,14 +60,14 @@ class NapalmLLDPSensor(PollingSensor):
 
             if this_lldp_neighbors > last_lldp_neighbors:
                 self._logger.info(
-                    "Peer count went UP to %s" % str(this_lldp_neighbors)
+                    "Device %s peer count went UP to %s" % (hostname, str(this_lldp_neighbors))
                 )
                 self._lldp_peer_trigger(NEIGHBOR_INCREASE, hostname,
                                         last_lldp_neighbors, this_lldp_neighbors)
 
             elif this_lldp_neighbors < last_lldp_neighbors:
                 self._logger.info(
-                    "LLDP neighbors went DOWN to %s" % str(this_lldp_neighbors)
+                    "Device %s LLDP nbrs went DOWN to %s" % (hostname, str(this_lldp_neighbors))
                 )
 
                 self._lldp_peer_trigger(NEIGHBOR_DECREASE, hostname,
@@ -75,7 +75,7 @@ class NapalmLLDPSensor(PollingSensor):
 
             elif this_lldp_neighbors == last_lldp_neighbors:
                 self._logger.info(
-                    "LLDP neighbors STAYED at %s" % str(this_lldp_neighbors)
+                    "Device %s LLDP nbrs STAYED at %s" % (hostname, str(this_lldp_neighbors))
                 )
 
             # Save this state for the next poll
@@ -122,5 +122,4 @@ class NapalmLLDPSensor(PollingSensor):
             'newpeers': int(newpeers),
             'timestamp': str(datetime.now()),
         }
-        self._logger.debug("DISPATCHING TRIGGER %s" % trigger)
         self._sensor_service.dispatch(trigger=trigger, payload=payload)

--- a/sensors/lldp_sensor.yaml
+++ b/sensors/lldp_sensor.yaml
@@ -2,7 +2,7 @@
 class_name: "NapalmLLDPSensor"
 entry_point: "lldp_sensor.py"
 description: "Sensor that uses NAPALM to retrieve LLDP information from network devices"
-enabled: false
+enabled: false  # disabled by default; this is for demo purposes only.
 
 trigger_types:
 

--- a/sensors/lldp_sensor.yaml
+++ b/sensors/lldp_sensor.yaml
@@ -2,6 +2,7 @@
 class_name: "NapalmLLDPSensor"
 entry_point: "lldp_sensor.py"
 description: "Sensor that uses NAPALM to retrieve LLDP information from network devices"
+enabled: false
 
 trigger_types:
 

--- a/sensors/lldp_sensor.yaml
+++ b/sensors/lldp_sensor.yaml
@@ -1,0 +1,34 @@
+---
+class_name: "NapalmLLDPSensor"
+entry_point: "lldp_sensor.py"
+description: "Sensor that uses NAPALM to retrieve LLDP information from network devices"
+
+trigger_types:
+
+- name: "NeighborIncrease"
+  description: "Trigger which occurs when a device's LLDP neighbors increase"
+  payload_schema:
+    type: "object"
+    properties:
+      device:
+        type: "string"
+      oldpeers:
+        type: "integer"
+      newpeers:
+        type: "integer"
+      timestamp:
+        type: "string"
+
+- name: "NeighborDecrease"
+  description: "Trigger which occurs when a device's LLDP neighbors decrease"
+  payload_schema:
+    type: "object"
+    properties:
+      device:
+        type: "string"
+      oldpeers:
+        type: "integer"
+      newpeers:
+        type: "integer"
+      timestamp:
+        type: "string"

--- a/sensors/lldp_sensor.yaml
+++ b/sensors/lldp_sensor.yaml
@@ -6,7 +6,7 @@ enabled: false
 
 trigger_types:
 
-- name: "NeighborIncrease"
+- name: "LLDPNeighborDecrease"
   description: "Trigger which occurs when a device's LLDP neighbors increase"
   payload_schema:
     type: "object"
@@ -20,7 +20,7 @@ trigger_types:
       timestamp:
         type: "string"
 
-- name: "NeighborDecrease"
+- name: "LLDPNeighborDecrease"
   description: "Trigger which occurs when a device's LLDP neighbors decrease"
   payload_schema:
     type: "object"


### PR DESCRIPTION
For my Interop 2017 workshop, I implemented an example sensor for detecting LLDP neighbor changes. I figured it was worth adding to the pack. I have disabled it by default because, as I mention in the README, it is not for production usage.