### PR TITLE
Removed redundant get_ntp code, implemented "query_type"

### DIFF
--- a/actions/get_ntp.py
+++ b/actions/get_ntp.py
@@ -8,13 +8,8 @@ class NapalmGetNTP(NapalmBaseAction):
     def run(self, query_type, **std_kwargs):
 
         try:
-            if not query_type:
-                query_type = 'stats'
-            else:
-                query_type = type.lower()
-                if query_type not in ["stats", "servers", "peers"]:
-                    raise ValueError(('{} is not a valid ntp query type use: '
-                                      'stats, servers or peers.').format(query_type))
+
+            query_type = query_type.lower()
 
             with self.get_driver(**std_kwargs) as device:
 
@@ -24,10 +19,6 @@ class NapalmGetNTP(NapalmBaseAction):
                     ntp_result = {'raw': device.get_ntp_servers()}
                 elif type == "peers":
                     ntp_result = {'raw': device.get_ntp_peers()}
-                else:
-                    raise ValueError(('{} is not a valid ntp query type use: '
-                                      'stats, servers or peers.').format(type))
-
                 if self.htmlout:
                     ntp_result['html'] = self.html_out(ntp_result['raw'])
 

--- a/actions/get_ntp.yaml
+++ b/actions/get_ntp.yaml
@@ -35,3 +35,10 @@ parameters:
         description: "In addition to the normal output also includes html output."
         required: false
         position: 5
+    query_type:
+        type: "string"
+        description: "The type of query to execute."
+        default: 'stats'
+        enum: ['stats', 'servers', 'peers']
+        required: false
+        position: 6

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - juniper
     - arista
     - ibm
-version: 0.2.3
+version: 0.2.4
 author: mierdin, Rob Woodward
 email: info@stackstorm.com


### PR DESCRIPTION
The `query_type` param was missing from the metadata, so I implemented that.

Also, a lot of what was implemented in the action is provided automatically through metadata, so I moved that logic to YAML