### PR TITLE
Added missing credentials section to config schema

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,5 @@
+# Change Log
+
+## 0.2.5
+
+- Added missing "credentials" section to `config.schema.yaml`

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ These will be installed for you when you install the pack using `st2 pack instal
 
 ## Configuration
 
-Look at config.schema.yaml. The napalm.yaml.example file as a base to start
-the configuration which needs to be copied into your stackstorm configs
-directory (/opt/stackstorm/configs/ by default on debian/ubuntu) as napalm.yaml.
-This is where you'll need to tell StackStorm about the network devices
-you wish use and the credentails for logging into the devices.
+The `napalm.yaml.example` file is an example configuration file.
+Copy this to `/opt/stackstorm/configs/napalm.yaml`, and edit as required.
+
+This is where you tell StackStorm about your network devices, their types,
+and credentials to manage the devices.
 
 ### Credentials configuration
 
@@ -105,6 +105,9 @@ devices:
   driver: junos
   credentials: customer
 ```
+
+After you have finished editing `/opt/stackstorm/configs/napalm.yaml`, you must tell
+StackStorm to load the configuration, with `sudo st2ctl reload --register-configs`
 
 ## Actions
 

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -29,3 +29,25 @@ devices:
         description: "Credentials group used to login to the device"
         type: "string"
         required: true
+
+credentials:
+  type: "object"
+  required: true
+  patternProperties:
+      "^\\w+":
+        "$ref": "#/properties/cred_group"
+  additionalProperties: false
+
+cred_group:
+  type: "object"
+  properties:
+    user:
+      description: "Username for network device"
+      type: "string"
+      required: true
+    password:
+      description: "Password for network device"
+      type: "string"
+      secret: true
+      required: true
+  additionalProperties: false

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -41,7 +41,7 @@ credentials:
 cred_group:
   type: "object"
   properties:
-    user:
+    username:
       description: "Username for network device"
       type: "string"
       required: true

--- a/pack.yaml
+++ b/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: napalm
-description: A StackStorm pack for working with network devices using the NAPALM library
+description: NAPALM network automation library integration pack
 keywords:
     - networking
     - napalm
@@ -8,6 +8,6 @@ keywords:
     - juniper
     - arista
     - ibm
-version: 0.2.4
+version: 0.2.5
 author: mierdin, Rob Woodward
 email: info@stackstorm.com


### PR DESCRIPTION
Added missing "credentials" section to `config.schema.yaml`. Note that this was already in the example configuration, and the pack itself assumes a credentials section.

Fixes #22 