### PR TITLE
Add port to pack config

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.7
+
+- Added "port" parameter to configuration (sensor now able to set port, actions use this as secondary)
+
 ## 0.2.5
 
 - Added missing "credentials" section to `config.schema.yaml`

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -21,6 +21,10 @@ devices:
         description: "Hostname for the device"
         type: "string"
         required: true
+      port:
+        description: "Port for the device"
+        type: "integer"
+        required: false
       driver:
         description: "Driver for the device"
         type: "string"

--- a/napalm.yaml.example
+++ b/napalm.yaml.example
@@ -12,8 +12,10 @@ credentials:
 
 devices:
 - hostname: router1.lon
+  port: 22
   driver: junos
   credentials: core
 - hostname: router2.par
+  port: 22
   driver: junos
   credentials: customer

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - juniper
     - arista
     - ibm
-version: 0.2.6
+version: 0.2.7
 author: mierdin, Rob Woodward
 email: info@stackstorm.com


### PR DESCRIPTION
Since this pack was created, users have been able to provide the port via an optional Action parameter. However, with the introduction of a sensor in #19, we need to ensure this is available via the pack config as well so that Sensors can derive this value somewhere.

Like other parameters, Actions will prefer `port` Action parameter above all. If not provided, it will fall back to what's in the config. Unlike other parameters though, if `port` is not provided in either case, the Action will punt the decision to NAPALM, which will impose its own per-driver default.
