### PR TITLE
Improve visibility and exception clarity

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## 0.2.8
+
+- Removes unnecessary exception handling in each action. Was suppressing useful information about the problem
+- Catch KeyError when referencing certain config items and provide useful message - clear indicator that config needs provided/reloaded
+
 ## 0.2.7
 
 - Added "port" parameter to configuration (sensor now able to set port, actions use this as secondary)

--- a/actions/cli.py
+++ b/actions/cli.py
@@ -7,27 +7,22 @@ class NapalmCLI(NapalmBaseAction):
 
     def run(self, commands, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
-                cmds_output = device.cli(commands)
+        with self.get_driver(**std_kwargs) as device:
+            cmds_output = device.cli(commands)
 
-                result = {'raw': cmds_output}
+            result = {'raw': cmds_output}
 
-                result_with_pre = {}
-                result_as_array = {}
+            result_with_pre = {}
+            result_as_array = {}
 
-                for this_cmd in cmds_output:
-                    result_as_array[this_cmd] = cmds_output[this_cmd].split('\n')
-                    if self.htmlout:
-                        result_with_pre[this_cmd] = "<pre>" + cmds_output[this_cmd] + "</pre>"
-
-                result['raw_array'] = result_as_array
-
+            for this_cmd in cmds_output:
+                result_as_array[this_cmd] = cmds_output[this_cmd].split('\n')
                 if self.htmlout:
-                    result['html'] = self.html_out(result_with_pre)
+                    result_with_pre[this_cmd] = "<pre>" + cmds_output[this_cmd] + "</pre>"
 
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            result['raw_array'] = result_as_array
+
+            if self.htmlout:
+                result['html'] = self.html_out(result_with_pre)
 
         return (True, result)

--- a/actions/get_arp_table.py
+++ b/actions/get_arp_table.py
@@ -7,15 +7,9 @@ class NapalmGetARPTable(NapalmBaseAction):
 
     def run(self, **std_kwargs):
 
-        try:
-
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_arp_table()}
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_arp_table()}
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_bgp_config.py
+++ b/actions/get_bgp_config.py
@@ -7,27 +7,22 @@ class NapalmGetBGPConfig(NapalmBaseAction):
 
     def run(self, group, neighbor, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
+        with self.get_driver(**std_kwargs) as device:
 
-                if not group:
-                    if not neighbor:
-                        bgpconf = device.get_bgp_config()
-                    else:
-                        bgpconf = device.get_bgp_config(neighbor=neighbor)
+            if not group:
+                if not neighbor:
+                    bgpconf = device.get_bgp_config()
                 else:
-                    if not neighbor:
-                        bgpconf = device.get_bgp_config(group=group)
-                    else:
-                        bgpconf = device.get_bgp_config(group=group, neighbor=neighbor)
+                    bgpconf = device.get_bgp_config(neighbor=neighbor)
+            else:
+                if not neighbor:
+                    bgpconf = device.get_bgp_config(group=group)
+                else:
+                    bgpconf = device.get_bgp_config(group=group, neighbor=neighbor)
 
-                result = {'raw': bgpconf}
+            result = {'raw': bgpconf}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_bgp_neighbors.py
+++ b/actions/get_bgp_neighbors.py
@@ -7,30 +7,25 @@ class NapalmGetBGPneighbors(NapalmBaseAction):
 
     def run(self, routing_instance, neighbor, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
-                result = device.get_bgp_neighbors()
+        with self.get_driver(**std_kwargs) as device:
+            result = device.get_bgp_neighbors()
 
-                if routing_instance not in result:
-                    raise ValueError(('Routing instance {} does not exist on '
-                                      'this device.').format(routing_instance))
+            if routing_instance not in result:
+                raise ValueError(('Routing instance {} does not exist on '
+                                  'this device.').format(routing_instance))
 
-                if not neighbor:
-                    bgp_neighbors = result[routing_instance]['peers']
+            if not neighbor:
+                bgp_neighbors = result[routing_instance]['peers']
+            else:
+                if neighbor not in result[routing_instance]['peers']:
+                    raise ValueError(('BGP neighbor {} does not exist '
+                                      'on this device.').format(neighbor))
                 else:
-                    if neighbor not in result[routing_instance]['peers']:
-                        raise ValueError(('BGP neighbor {} does not exist '
-                                          'on this device.').format(neighbor))
-                    else:
-                        bgp_neighbors = result[routing_instance]['peers'][neighbor]
+                    bgp_neighbors = result[routing_instance]['peers'][neighbor]
 
-                result = {'raw': bgp_neighbors}
+            result = {'raw': bgp_neighbors}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_bgp_neighbors_detail.py
+++ b/actions/get_bgp_neighbors_detail.py
@@ -5,15 +5,10 @@ class NapalmGetBGPNeighborDetail(NapalmBaseAction):
 
     def run(self, neighbor, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_bgp_neighbors_detail(neighbor)}
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_bgp_neighbors_detail(neighbor)}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_config.py
+++ b/actions/get_config.py
@@ -5,20 +5,15 @@ class NapalmGetConfig(NapalmBaseAction):
 
     def run(self, retrieve, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
+        with self.get_driver(**std_kwargs) as device:
 
-                if not retrieve:
-                    config_output = device.get_config()
-                else:
-                    config_output = device.get_config(retrieve)
+            if not retrieve:
+                config_output = device.get_config()
+            else:
+                config_output = device.get_config(retrieve)
 
-                result = {'raw': config_output}
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            result = {'raw': config_output}
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_environment.py
+++ b/actions/get_environment.py
@@ -7,15 +7,10 @@ class NapalmGetEnv(NapalmBaseAction):
 
     def run(self, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_environment()}
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_environment()}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_facts.py
+++ b/actions/get_facts.py
@@ -7,15 +7,10 @@ class NapalmGetFacts(NapalmBaseAction):
 
     def run(self, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_facts()}
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_facts()}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_firewall_policies.py
+++ b/actions/get_firewall_policies.py
@@ -7,15 +7,10 @@ class NapalmGetFirewallPolicies(NapalmBaseAction):
 
     def run(self, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_firewall_policies()}
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_firewall_policies()}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_interfaces.py
+++ b/actions/get_interfaces.py
@@ -7,31 +7,25 @@ class NapalmGetInterfaces(NapalmBaseAction):
 
     def run(self, interface=None, counters=False, ipaddresses=False, **std_kwargs):
 
-        try:
+        if counters and ipaddresses:
+            raise ValueError("Both ipaddresses and counters can not be set at the same time.")
 
-            if counters and ipaddresses:
-                raise ValueError("Both ipaddresses and counters can not be set at the same time.")
+        with self.get_driver(**std_kwargs) as device:
 
-            with self.get_driver(**std_kwargs) as device:
+            if counters:
+                result = device.get_interfaces_counters()
+            elif ipaddresses:
+                result = device.get_interfaces_ip()
+            else:
+                result = device.get_interfaces()
 
-                if counters:
-                    result = device.get_interfaces_counters()
-                elif ipaddresses:
-                    result = device.get_interfaces_ip()
-                else:
-                    result = device.get_interfaces()
+            if interface:
+                interfaces = {"raw": result.get(interface)}
+                interfaces['raw']['name'] = interface
+            else:
+                interfaces = {"raw": result}
 
-                if interface:
-                    interfaces = {"raw": result.get(interface)}
-                    interfaces['raw']['name'] = interface
-                else:
-                    interfaces = {"raw": result}
-
-                if self.htmlout:
-                    interfaces['html'] = self.html_out(interfaces['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                interfaces['html'] = self.html_out(interfaces['raw'])
 
         return (True, interfaces)

--- a/actions/get_lldp_neighbors.py
+++ b/actions/get_lldp_neighbors.py
@@ -7,19 +7,14 @@ class NapalmGetLLDPNeighbors(NapalmBaseAction):
 
     def run(self, interface, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
+        with self.get_driver(**std_kwargs) as device:
 
-                if not interface:
-                    lldp_neighbors = {'raw': device.get_lldp_neighbors()}
-                else:
-                    lldp_neighbors = {'raw': device.get_lldp_neighbors_detail(interface)}
+            if not interface:
+                lldp_neighbors = {'raw': device.get_lldp_neighbors()}
+            else:
+                lldp_neighbors = {'raw': device.get_lldp_neighbors_detail(interface)}
 
-                if self.htmlout:
-                    lldp_neighbors['html'] = self.html_out(lldp_neighbors['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                lldp_neighbors['html'] = self.html_out(lldp_neighbors['raw'])
 
         return (True, lldp_neighbors)

--- a/actions/get_log.py
+++ b/actions/get_log.py
@@ -7,47 +7,41 @@ class NapalmGetLog(NapalmBaseAction):
 
     def run(self, lastlines=5, **std_kwargs):
 
-        try:
+        cmd_dict = {
+            "junos": {
+                "log_cmd": "show log messages",
+                "commands": ['set cli screen-width 0', 'set cli screen-length 0']
+            },
+            "iosxr": {
+                "log_cmd": "show log",
+                "commands": ['term width 0', 'term len 0']
+            },
+            "ios": {
+                "log_cmd": "show log",
+                "commands": ['term width 0', 'term len 0']
+            },
+            "eos": {
+                "log_cmd": "show log",
+                "commands": ['term width 32767', 'term len 0']
+            },
+        }
 
-            cmd_dict = {
-                "junos": {
-                    "log_cmd": "show log messages",
-                    "commands": ['set cli screen-width 0', 'set cli screen-length 0']
-                },
-                "iosxr": {
-                    "log_cmd": "show log",
-                    "commands": ['term width 0', 'term len 0']
-                },
-                "ios": {
-                    "log_cmd": "show log",
-                    "commands": ['term width 0', 'term len 0']
-                },
-                "eos": {
-                    "log_cmd": "show log",
-                    "commands": ['term width 32767', 'term len 0']
-                },
-            }
+        with self.get_driver(**std_kwargs) as device:
 
-            with self.get_driver(**std_kwargs) as device:
+            try:
+                log_cmd = cmd_dict[self.driver]["log_cmd"]
+                commands = cmd_dict[self.driver]["commands"]
+                commands.append(log_cmd)
+            except KeyError:
+                self.logger.error('Not able to find logging command for {}, '
+                                  'with driver {}.').format(self.hostname, self.driver)
+                raise
 
-                try:
-                    log_cmd = cmd_dict[self.driver]["log_cmd"]
-                    commands = cmd_dict[self.driver]["commands"]
-                    commands.append(log_cmd)
-                except KeyError:
-                    self.logger.error('Not able to find logging command for {}, '
-                                      'with driver {}.').format(self.hostname, self.driver)
-                    raise
+            cmd_result = device.cli(commands)
+            log_output = list(filter(None, cmd_result[log_cmd].split('\n')))
+            result = {"raw": log_output[-lastlines:]}
 
-                cmd_result = device.cli(commands)
-                log_output = list(filter(None, cmd_result[log_cmd].split('\n')))
-                result = {"raw": log_output[-lastlines:]}
-
-            if self.htmlout:
-                result['html'] = "<pre>" + "\n".join(result['raw']) + "</pre>"
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+        if self.htmlout:
+            result['html'] = "<pre>" + "\n".join(result['raw']) + "</pre>"
 
         return (True, result)

--- a/actions/get_mac_address_table.py
+++ b/actions/get_mac_address_table.py
@@ -7,15 +7,10 @@ class NapalmGetMACTable(NapalmBaseAction):
 
     def run(self, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_mac_address_table()}
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_mac_address_table()}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_network_instances.py
+++ b/actions/get_network_instances.py
@@ -7,19 +7,14 @@ class NapalmGetNetworkInstances(NapalmBaseAction):
 
     def run(self, name, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
+        with self.get_driver(**std_kwargs) as device:
 
-                if not name:
-                    network_instances = {'raw': device.get_network_instances()}
-                else:
-                    network_instances = {'raw': device.get_network_instances(name)}
+            if not name:
+                network_instances = {'raw': device.get_network_instances()}
+            else:
+                network_instances = {'raw': device.get_network_instances(name)}
 
-                if self.htmlout:
-                    network_instances['html'] = self.html_out(network_instances['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                network_instances['html'] = self.html_out(network_instances['raw'])
 
         return (True, network_instances)

--- a/actions/get_ntp.py
+++ b/actions/get_ntp.py
@@ -7,23 +7,17 @@ class NapalmGetNTP(NapalmBaseAction):
 
     def run(self, query_type, **std_kwargs):
 
-        try:
+        query_type = query_type.lower()
 
-            query_type = query_type.lower()
+        with self.get_driver(**std_kwargs) as device:
 
-            with self.get_driver(**std_kwargs) as device:
-
-                if type == "stats":
-                    ntp_result = {'raw': device.get_ntp_stats()}
-                elif type == "servers":
-                    ntp_result = {'raw': device.get_ntp_servers()}
-                elif type == "peers":
-                    ntp_result = {'raw': device.get_ntp_peers()}
-                if self.htmlout:
-                    ntp_result['html'] = self.html_out(ntp_result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if type == "stats":
+                ntp_result = {'raw': device.get_ntp_stats()}
+            elif type == "servers":
+                ntp_result = {'raw': device.get_ntp_servers()}
+            elif type == "peers":
+                ntp_result = {'raw': device.get_ntp_peers()}
+            if self.htmlout:
+                ntp_result['html'] = self.html_out(ntp_result['raw'])
 
         return (True, ntp_result)

--- a/actions/get_optics.py
+++ b/actions/get_optics.py
@@ -7,15 +7,10 @@ class NapalmOptics(NapalmBaseAction):
 
     def run(self, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_optics()}
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_optics()}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_probes_config.py
+++ b/actions/get_probes_config.py
@@ -7,19 +7,14 @@ class NapalmGetProbesConfig(NapalmBaseAction):
 
     def run(self, **std_kwargs):
 
-        try:
-            if self.driver not in ["iosxr", "junos"]:
-                raise ValueError(('Not supported with {} driver, only IOS-XR and JunOS '
-                                  'are supported.').format(self.driver))
+        if self.driver not in ["iosxr", "junos"]:
+            raise ValueError(('Not supported with {} driver, only IOS-XR and JunOS '
+                              'are supported.').format(self.driver))
 
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_probes_config()}
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_probes_config()}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_probes_results.py
+++ b/actions/get_probes_results.py
@@ -7,19 +7,13 @@ class NapalmGetProbesResults(NapalmBaseAction):
 
     def run(self, **std_kwargs):
 
-        try:
+        if self.driver not in ["iosxr", "junos"]:
+            raise ValueError(('Not supported with {} driver, only IOS-XR '
+                              'and JunOS are supported.').format(self.driver))
 
-            if self.driver not in ["iosxr", "junos"]:
-                raise ValueError(('Not supported with {} driver, only IOS-XR '
-                                  'and JunOS are supported.').format(self.driver))
-
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_probes_results()}
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_probes_results()}
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/get_route_to.py
+++ b/actions/get_route_to.py
@@ -7,19 +7,14 @@ class NapalmGetRouteTo(NapalmBaseAction):
 
     def run(self, destination, protocol, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
+        with self.get_driver(**std_kwargs) as device:
 
-                if not protocol:
-                    route = {'raw': device.get_route_to(destination)}
-                else:
-                    route = {'raw': device.get_route_to(destination, protocol)}
+            if not protocol:
+                route = {'raw': device.get_route_to(destination)}
+            else:
+                route = {'raw': device.get_route_to(destination, protocol)}
 
-                if self.htmlout:
-                    route['html'] = self.html_out(route['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                route['html'] = self.html_out(route['raw'])
 
         return (True, route)

--- a/actions/get_snmp_information.py
+++ b/actions/get_snmp_information.py
@@ -7,15 +7,10 @@ class NapalmGetSNMPInformation(NapalmBaseAction):
 
     def run(self, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
-                result = {'raw': device.get_snmp_information()}
+        with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.get_snmp_information()}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -77,7 +77,15 @@ class NapalmBaseAction(Action):
         """Locates device in configuration based on search parameters
         """
 
-        devices = self.config['devices']
+        try:
+            devices = self.config['devices']
+        except KeyError:
+            # Probably means the user needs to provide a config and/or
+            # reload with `st2ctl reload --register-configs`, so we can
+            # provide helpful error message
+            message = ("Configuration Error: Please provide a pack config and ensure it's loaded "
+                       " with `st2ctl reload --register-configs`")
+            raise Exception(message)
 
         search = search.lower()
 

--- a/actions/loadconfig.py
+++ b/actions/loadconfig.py
@@ -7,26 +7,21 @@ class NapalmLoadConfig(NapalmBaseAction):
 
     def run(self, config_file, method, **std_kwargs):
 
-        try:
-            if not method:
-                method = 'merge'
+        if not method:
+            method = 'merge'
+        else:
+            method = method.lower()
+            if method not in ["merge", "replace"]:
+                raise ValueError(('{} is not a valid load method, use: '
+                                  'merge or replace').format(method))
+
+        with self.get_driver(**std_kwargs) as device:
+
+            if method == "replace":
+                device.load_replace_candidate(filename=config_file)
             else:
-                method = method.lower()
-                if method not in ["merge", "replace"]:
-                    raise ValueError(('{} is not a valid load method, use: '
-                                      'merge or replace').format(method))
+                device.load_merge_candidate(filename=config_file)
 
-            with self.get_driver(**std_kwargs) as device:
-
-                if method == "replace":
-                    device.load_replace_candidate(filename=config_file)
-                else:
-                    device.load_merge_candidate(filename=config_file)
-
-                device.commit_config()
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            device.commit_config()
 
         return (True, "load ({}) successful on {}".format(method, self.hostname))

--- a/actions/ping.py
+++ b/actions/ping.py
@@ -7,17 +7,11 @@ class NapalmPing(NapalmBaseAction):
 
     def run(self, destination, source, ttl=255, pingtout=2, size=100, count=5, **std_kwargs):
 
-        try:
+        with self.get_driver(**std_kwargs) as device:
 
-            with self.get_driver(**std_kwargs) as device:
+            result = {'raw': device.ping(destination, source, ttl, pingtout, size, count)}
 
-                result = {'raw': device.ping(destination, source, ttl, pingtout, size, count)}
-
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/actions/traceroute.py
+++ b/actions/traceroute.py
@@ -7,16 +7,11 @@ class NapalmTraceroute(NapalmBaseAction):
 
     def run(self, destination, source, ttl=255, trtimeout=2, **std_kwargs):
 
-        try:
-            with self.get_driver(**std_kwargs) as device:
+        with self.get_driver(**std_kwargs) as device:
 
-                result = {'raw': device.traceroute(destination, source, ttl, trtimeout)}
+            result = {'raw': device.traceroute(destination, source, ttl, trtimeout)}
 
-                if self.htmlout:
-                    result['html'] = self.html_out(result['raw'])
-
-        except Exception, e:
-            self.logger.error(str(e))
-            return (False, str(e))
+            if self.htmlout:
+                result['html'] = self.html_out(result['raw'])
 
         return (True, result)

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - juniper
     - arista
     - ibm
-version: 0.2.7
+version: 0.2.8
 author: mierdin, Rob Woodward
 email: info@stackstorm.com


### PR DESCRIPTION
# Summary

- Removes unnecessary exception handling in each action. Was suppressing useful information about the problem
- Catch KeyError when referencing certain config items and provide useful message - clear indicator that config needs provided/reloaded

## Stop Suppressing Output

Each action had an unnecessary try...except, which didn't do much for us other than log the exception message. It didn't do a great job at this either, resulting in really strange error messages:

```
vagrant@st2vagrant:~$ st2 run napalm.get_interfaces hostname=vsrx01
................................................................
id: 59b09093c4da5f2f83a5462a
status: failed
parameters:
  hostname: vsrx01
result:
  exit_code: 0
  result: ''
  stderr: "st2.actions.python.NapalmGetInterfaces: ERROR    \n"
  stdout: ''
```

This PR removes those, so that any exceptions are just raised to the user directly.

## KeyError when config not loaded

Previously, we'd get a cryptic error when we had initially installed the pack, but forgotten to configure it (and/or forgotten to run `st2ctl reload --register-configs`):

```
vagrant@st2vagrant:~$ st2 run napalm.get_interfaces hostname=vsrx01
.
id: 59b08f75c4da5f2f83a54627
status: failed
parameters:
  hostname: vsrx01
result:
  exit_code: 0
  result: '''devices'''
  stderr: 'st2.actions.python.NapalmGetInterfaces: ERROR    ''devices''

    '
  stdout: ''
```

This is because the common action code in `lib/` was statically referring to keys in the configuration, and there was no error handling, so a `KeyError` would be raised. This was cryptic enough, but then the aforementioned catch-all error handling would catch this and further obfuscate the true nature of the problem.

So, this PR adds a `KeyError`-specific catch, and supplies a more straightforward error message:

```
vagrant@st2vagrant:~$ st2 run napalm.get_interfaces hostname=vsrx01
.
id: 59b08ee6c4da5f2f83a545f6
status: failed
parameters:
  hostname: vsrx01
result:
  exit_code: 1
  result: None
  stderr: "Traceback (most recent call last):\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 259, in <module>\n    obj.run()\n  File \"/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/runners/python_action_wrapper.py\", line 155, in run\n    output = action.run(**self._parameters)\n  File \"/opt/stackstorm/packs/napalm/actions/get_interfaces.py\", line 13, in run\n    with self.get_driver(**std_kwargs) as device:\n  File \"/opt/stackstorm/packs/napalm/actions/lib/action.py\", line 37, in get_driver\n    found_device = self.find_device_from_config(hostname, driver, credentials, port)\n  File \"/opt/stackstorm/packs/napalm/actions/lib/action.py\", line 88, in find_device_from_config\n    raise Exception(message)\nException: Configuration Error: Please provide a pack config and ensure it's loaded  with `st2ctl reload --register-configs`\n"
  stdout: ''
```

Closes https://github.com/StackStorm-Exchange/stackstorm-napalm/issues/32
