### PR TITLE
Added a new parameter (config_text) to loadconfig action to be able to specify a command to set to device as text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.11
+
+- Added "config_text" parameter to loadconfig action to be able to specify a command to set to device as text
+
 ## 0.2.8
 
 - Removes unnecessary exception handling in each action. Was suppressing useful information about the problem

--- a/actions/loadconfig.py
+++ b/actions/loadconfig.py
@@ -1,33 +1,23 @@
 from lib.action import NapalmBaseAction
 
-from napalm.base.exceptions import MergeConfigException
-from napalm.base.exceptions import ReplaceConfigException
-
 
 class NapalmLoadConfig(NapalmBaseAction):
     """Load configuration into network device via NAPALM
     """
 
     def run(self, config_file, config_text, method, inline_transfer, **std_kwargs):
-        try:
-            if not config_file and not config_text:
-                raise ValueError('Specify either config_file or config_text')
+        if not config_file and not config_text:
+            raise ValueError('Specify either config_file or config_text')
 
-            with self.get_driver(**std_kwargs) as device:
-                # inline_transfer: If set it becomes True, else False
-                device.inline_transfer = inline_transfer
+        with self.get_driver(**std_kwargs) as device:
+            # inline_transfer: If set it becomes True, else False
+            device.inline_transfer = inline_transfer
 
-                if method == "replace":
-                    device.load_replace_candidate(filename=config_file, config=config_text)
-                else:
-                    device.load_merge_candidate(filename=config_file, config=config_text)
+            if method == "replace":
+                device.load_replace_candidate(filename=config_file, config=config_text)
+            else:
+                device.load_merge_candidate(filename=config_file, config=config_text)
 
-                device.commit_config()
-        except ValueError as e:
-            return (False, e.message)
-        except ReplaceConfigException as e:
-            return (False, e.message)
-        except MergeConfigException as e:
-            return (False, e.message)
+            device.commit_config()
 
         return (True, "load ({}) successful on {}".format(method, self.hostname))

--- a/actions/loadconfig.py
+++ b/actions/loadconfig.py
@@ -1,29 +1,30 @@
 from lib.action import NapalmBaseAction
 
+from napalm.base.exceptions import MergeConfigException
+from napalm.base.exceptions import ReplaceConfigException
+
 
 class NapalmLoadConfig(NapalmBaseAction):
     """Load configuration into network device via NAPALM
     """
 
-    def run(self, config_file, method, inline_transfer, **std_kwargs):
+    def run(self, config_file, config_text, method, inline_transfer, **std_kwargs):
+        try:
+            with self.get_driver(**std_kwargs) as device:
+                # inline_transfer: If set it becomes True, else False
+                device.inline_transfer = inline_transfer
 
-        if not method:
-            method = 'merge'
-        else:
-            method = method.lower()
-            if method not in ["merge", "replace"]:
-                raise ValueError(('{} is not a valid load method, use: '
-                                  'merge or replace').format(method))
+                if method == "replace":
+                    device.load_replace_candidate(filename=config_file, config=config_text)
+                else:
+                    device.load_merge_candidate(filename=config_file, config=config_text)
 
-        with self.get_driver(**std_kwargs) as device:
-            # inline_transfer: If set it becomes True, else False
-            device.inline_transfer = inline_transfer
-
-            if method == "replace":
-                device.load_replace_candidate(filename=config_file)
-            else:
-                device.load_merge_candidate(filename=config_file)
-
-            device.commit_config()
+                device.commit_config()
+        except ValueError as e:
+            return (False, e.message)
+        except ReplaceConfigException as e:
+            return (False, e.message)
+        except MergeConfigException as e:
+            return (False, e.message)
 
         return (True, "load ({}) successful on {}".format(method, self.hostname))

--- a/actions/loadconfig.py
+++ b/actions/loadconfig.py
@@ -10,6 +10,9 @@ class NapalmLoadConfig(NapalmBaseAction):
 
     def run(self, config_file, config_text, method, inline_transfer, **std_kwargs):
         try:
+            if not config_file and not config_text:
+                raise ValueError('Specify either config_file or config_text')
+
             with self.get_driver(**std_kwargs) as device:
                 # inline_transfer: If set it becomes True, else False
                 device.inline_transfer = inline_transfer

--- a/actions/loadconfig.yaml
+++ b/actions/loadconfig.yaml
@@ -28,17 +28,25 @@ parameters:
     config_file:
         type: "string"
         description: "Absolute path to configuration file on local system that will be sent to the device"
-        required: true
+        required: false
         position: 4
+    config_text:
+        type: "string"
+        description: "A command that will be sent to the device"
+        required: false
+        position: 5
     method:
         type: "string"
         description: "Method to load the config (either 'merge' or 'replace', default is 'merge')"
         required: false
-        position: 5
+        position: 6
+        enum:
+            - merge
+            - replace
+        default: merge
     inline_transfer:
         type: "boolean"
         default: False
         description: "If selected, the ios driver will use SSH and not SCP to transfer config" 
         required: false
-        position: 6
-
+        position: 7

--- a/actions/loadconfig.yaml
+++ b/actions/loadconfig.yaml
@@ -27,12 +27,12 @@ parameters:
         position: 3
     config_file:
         type: "string"
-        description: "Absolute path to configuration file on local system that will be sent to the device"
+        description: "Absolute path to configuration file on local system that will be sent to the device. Need to specify either config_file or config_text. If both given, config_file takes precedence."
         required: false
         position: 4
     config_text:
         type: "string"
-        description: "A command that will be sent to the device"
+        description: "A command that will be sent to the device. Need to specify either config_file or config_text. If both given, config_file takes precedence."
         required: false
         position: 5
     method:

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - juniper
     - arista
     - ibm
-version: 0.2.10
+version: 0.2.11
 author: mierdin, Rob Woodward
 email: info@stackstorm.com

--- a/tests/fixtures/full.yaml
+++ b/tests/fixtures/full.yaml
@@ -1,0 +1,1 @@
+../../napalm.yaml.example

--- a/tests/test_action_loadconfig.py
+++ b/tests/test_action_loadconfig.py
@@ -30,26 +30,24 @@ class NapalmLoadConfigTestCase(BaseActionTestCase):
 
         action = self.get_action_instance(self.full_config)
 
-        with self.assertRaises(KeyError):
+        with self.assertRaisesRegexp(KeyError, 'hostname'):
             action.run(**self.default_kwargs)
 
     def test_run_with_invalid_driver_parameter(self):
         self.default_kwargs['driver'] = 'invalid_driver'
 
         action = self.get_action_instance(self.full_config)
-        result = action.run(**self.default_kwargs)
-
-        self.assertFalse(result[0])
-        self.assertEqual(result[1], 'Driver "invalid_driver" is not a valid NAPALM Driver.')
+        with self.assertRaisesRegexp(ValueError,
+                                     'Driver "invalid_driver" is not a valid NAPALM Driver.'):
+            action.run(**self.default_kwargs)
 
     def test_run_without_credentials(self):
         del self.default_kwargs['credentials']
 
         action = self.get_action_instance(self.full_config)
-        result = action.run(**self.default_kwargs)
-
-        self.assertFalse(result[0])
-        self.assertEqual(result[1].find('Can not find credential group for host localhost'), 0)
+        with self.assertRaisesRegexp(ValueError,
+                                     'Can not find credential group for host localhost'):
+            action.run(**self.default_kwargs)
 
     @mock.patch('lib.action.get_network_driver')
     def test_run_with_incorrect_config_parameter_using_replace_method(self, mock_method):
@@ -68,10 +66,8 @@ class NapalmLoadConfigTestCase(BaseActionTestCase):
         mock_method.return_value = mock_driver
 
         action = self.get_action_instance(self.full_config)
-        result = action.run(**self.default_kwargs)
-
-        self.assertFalse(result[0])
-        self.assertEqual(result[1], err_msg)
+        with self.assertRaisesRegexp(exceptions.ReplaceConfigException, err_msg):
+            action.run(**self.default_kwargs)
 
     @mock.patch('lib.action.get_network_driver')
     def test_run_with_incorrect_config_parameter_using_merge_method(self, mock_method):
@@ -90,10 +86,8 @@ class NapalmLoadConfigTestCase(BaseActionTestCase):
         mock_method.return_value = mock_driver
 
         action = self.get_action_instance(self.full_config)
-        result = action.run(**self.default_kwargs)
-
-        self.assertFalse(result[0])
-        self.assertEqual(result[1], err_msg)
+        with self.assertRaisesRegexp(exceptions.MergeConfigException, err_msg):
+            action.run(**self.default_kwargs)
 
     @mock.patch('lib.action.get_network_driver')
     def test_run_with_correct_parameters(self, mock_method):
@@ -108,7 +102,6 @@ class NapalmLoadConfigTestCase(BaseActionTestCase):
         self.default_kwargs['config_file'] = self.default_kwargs['config_text'] = None
 
         action = self.get_action_instance(self.full_config)
-        result = action.run(**self.default_kwargs)
-
-        self.assertFalse(result[0])
-        self.assertEqual(result[1], 'Specify either config_file or config_text')
+        with self.assertRaisesRegexp(ValueError,
+                                     'Specify either config_file or config_text'):
+            action.run(**self.default_kwargs)

--- a/tests/test_action_loadconfig.py
+++ b/tests/test_action_loadconfig.py
@@ -19,7 +19,7 @@ class NapalmLoadConfigTestCase(BaseActionTestCase):
             'hostname': 'localhost',
             'driver': 'junos',
             'config_file': None,
-            'config_text': None,
+            'config_text': '/usr/local/etc/junos_config',
             'method': 'merge',
             'inline_transfer': False,
             'credentials': 'core',
@@ -102,3 +102,13 @@ class NapalmLoadConfigTestCase(BaseActionTestCase):
 
         self.assertTrue(result[0])
         self.assertEqual(result[1].find('load (merge) successful'), 0)
+
+    @mock.patch('lib.action.get_network_driver')
+    def test_run_without_both_config_file_and_text(self, mock_method):
+        self.default_kwargs['config_file'] = self.default_kwargs['config_text'] = None
+
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self.default_kwargs)
+
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], 'Specify either config_file or config_text')

--- a/tests/test_action_loadconfig.py
+++ b/tests/test_action_loadconfig.py
@@ -1,0 +1,104 @@
+import mock
+import yaml
+
+from st2tests.base import BaseActionTestCase
+from loadconfig import NapalmLoadConfig
+
+from napalm.base import exceptions
+
+
+class NapalmLoadConfigTestCase(BaseActionTestCase):
+    __test__ = True
+    action_cls = NapalmLoadConfig
+
+    def setUp(self):
+        super(NapalmLoadConfigTestCase, self).setUp()
+
+        self.full_config = yaml.safe_load(self.get_fixture_content('full.yaml'))
+        self.default_kwargs = {
+            'hostname': 'localhost',
+            'driver': 'junos',
+            'config_file': None,
+            'config_text': None,
+            'method': 'merge',
+            'inline_transfer': False,
+            'credentials': 'core',
+        }
+
+    def test_run_without_hostname_parameter(self):
+        del self.default_kwargs['hostname']
+
+        action = self.get_action_instance(self.full_config)
+
+        with self.assertRaises(KeyError):
+            action.run(**self.default_kwargs)
+
+    def test_run_with_invalid_driver_parameter(self):
+        self.default_kwargs['driver'] = 'invalid_driver'
+
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self.default_kwargs)
+
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], 'Driver "invalid_driver" is not a valid NAPALM Driver.')
+
+    def test_run_without_credentials(self):
+        del self.default_kwargs['credentials']
+
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self.default_kwargs)
+
+        self.assertFalse(result[0])
+        self.assertEqual(result[1].find('Can not find credential group for host localhost'), 0)
+
+    @mock.patch('lib.action.get_network_driver')
+    def test_run_with_incorrect_config_parameter_using_replace_method(self, mock_method):
+        # set parameter to fail
+        self.default_kwargs['config_text'] = 'invalid command'
+        self.default_kwargs['method'] = 'replace'
+
+        # prepare mock processing
+        err_msg = 'syntax error'
+        mock_device = mock.MagicMock()
+        mock_device.load_replace_candidate.side_effect = exceptions.ReplaceConfigException(err_msg)
+        mock_device.__enter__.return_value = mock_device
+
+        mock_driver = mock.MagicMock()
+        mock_driver.return_value = mock_device
+        mock_method.return_value = mock_driver
+
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self.default_kwargs)
+
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], err_msg)
+
+    @mock.patch('lib.action.get_network_driver')
+    def test_run_with_incorrect_config_parameter_using_merge_method(self, mock_method):
+        # set parameter to fail
+        self.default_kwargs['config_text'] = 'invalid command'
+        self.default_kwargs['method'] = 'merge'
+
+        # prepare mock processing
+        err_msg = 'syntax error'
+        mock_device = mock.MagicMock()
+        mock_device.load_merge_candidate.side_effect = exceptions.MergeConfigException(err_msg)
+        mock_device.__enter__.return_value = mock_device
+
+        mock_driver = mock.MagicMock()
+        mock_driver.return_value = mock_device
+        mock_method.return_value = mock_driver
+
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self.default_kwargs)
+
+        self.assertFalse(result[0])
+        self.assertEqual(result[1], err_msg)
+
+    @mock.patch('lib.action.get_network_driver')
+    def test_run_with_correct_parameters(self, mock_method):
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self.default_kwargs)
+
+        self.assertTrue(result[0])
+        self.assertEqual(result[1].find('load (merge) successful'), 0)


### PR DESCRIPTION
This is the patch for #37. This patch changes the action metadata of loadconfig as below
- Adding `config_text` parameter to accept configuration as text
- Disable `required` attribute at `config_file` parameter to be able to set only `config_text` instead of this to configure.
- Adding `enum` attribute at `method` parameter because this requires just only some specific values.

And this corrected the implementation of this action according to these changes, and also wrote tests for it.

Thank you.
