### PR TITLE
Support optional secret for devices needing enable mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.13
+
+- Support `secret` parameter for IOS devices that need password to enter enable mode
+
 ## 0.2.11
 
 - Added "config_text" parameter to loadconfig action to be able to specify a command to set to device as text

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -38,10 +38,13 @@ class NapalmBaseAction(Action):
 
         login = self.get_credentials(found_device['credentials'])
 
-        if not found_device['port']:
-            optional_args = None
-        else:
+        optional_args = {}
+
+        if 'port' in found_device:
             optional_args = {'port': int(found_device['port'])}
+
+        if 'secret' in login:
+            optional_args = {'secret': login['secret']}
 
         # Some actions like to use these params in log messages, or commands, etc.
         # So we tie to instance for easy lookup

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -40,7 +40,9 @@ class NapalmBaseAction(Action):
 
         optional_args = {}
 
-        if 'port' in found_device:
+        if not found_device['port']:
+            pass
+        else
             optional_args = {'port': int(found_device['port'])}
 
         if 'secret' in login:

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -42,7 +42,7 @@ class NapalmBaseAction(Action):
 
         if not found_device['port']:
             pass
-        else
+        else:
             optional_args = {'port': int(found_device['port'])}
 
         if 'secret' in login:

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -54,4 +54,9 @@ cred_group:
       type: "string"
       secret: true
       required: true
+    secret:
+      description: "Optional password for entering enable mode"
+      type: "string"
+      secret: true
+      required: false
   additionalProperties: false

--- a/napalm.yaml.example
+++ b/napalm.yaml.example
@@ -9,6 +9,10 @@ credentials:
   customer:
     username: customeruser
     password: customerpw
+  access:
+    username: ciscouser
+    password: ciscopw
+    secret: ciscoenable
 
 devices:
 - hostname: router1.lon
@@ -19,3 +23,7 @@ devices:
   port: 22
   driver: junos
   credentials: customer
+- hostname: router3.tok
+  port: 22
+  driver: ios
+  credentials: access

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - juniper
     - arista
     - ibm
-version: 0.2.12
+version: 0.2.13
 author: mierdin, Rob Woodward
 email: info@stackstorm.com


### PR DESCRIPTION
This PR adds support for defining an optional `secret` in the device credentials. This is mostly for IOS devices that need to enter enable mode, where people can't/won't use priv 15 by default.

Fixes #47 