### PR TITLE
Support SSH key file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.2.14
+
+- Support `key_file` for SSH key authentication
+
 ## 0.2.13
 
 - Support `secret` parameter for IOS devices that need password to enter enable mode

--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ credentials:
     password: customerpw
 ```
 
+You can also use an enable secret for those devices that require, or an SSH key
+file, e.g.:
+
+```yaml
+credentials:
+  cisco:
+    username: cisco
+    password: loginpass
+    secret: enablePass
+  juniper:
+    username: cisco
+    key_file: /opt/stackstorm/configs/id_rsa
+```
+
 ### Devices configuration
 
 The devices configuration is so that credentials and drivers for each device

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -49,7 +49,7 @@ class NapalmBaseAction(Action):
             optional_args = {'secret': login['secret']}
 
         if 'key_file' in login:
-            optional_args = {'key_file': login['key_file']}
+            optional_args = {'key_file': str(login['key_file'])}
             login['password'] = None
 
         # Some actions like to use these params in log messages, or commands, etc.

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -50,6 +50,7 @@ class NapalmBaseAction(Action):
 
         if 'key_file' in login:
             optional_args = {'key_file': login['key_file']}
+            login['password'] = None
 
         # Some actions like to use these params in log messages, or commands, etc.
         # So we tie to instance for easy lookup
@@ -73,7 +74,7 @@ class NapalmBaseAction(Action):
         if not authconfig:
             raise ValueError('Can not find credentials group {}.'.format(credentials))
 
-        if authconfig['password'] is None and authconfig['key_file'] is None:
+        if 'password' not in authconfig and 'key_file' not in authconfig:
             raise ValueError("Missing password or SSH key in credentials.")
 
         if authconfig['username'] is None:

--- a/actions/lib/action.py
+++ b/actions/lib/action.py
@@ -48,6 +48,9 @@ class NapalmBaseAction(Action):
         if 'secret' in login:
             optional_args = {'secret': login['secret']}
 
+        if 'key_file' in login:
+            optional_args = {'key_file': login['key_file']}
+
         # Some actions like to use these params in log messages, or commands, etc.
         # So we tie to instance for easy lookup
         self.hostname = found_device['hostname']
@@ -70,8 +73,8 @@ class NapalmBaseAction(Action):
         if not authconfig:
             raise ValueError('Can not find credentials group {}.'.format(credentials))
 
-        if authconfig['password'] is None:
-            raise ValueError("Missing password in credentials.")
+        if authconfig['password'] is None and authconfig['key_file'] is None:
+            raise ValueError("Missing password or SSH key in credentials.")
 
         if authconfig['username'] is None:
             raise ValueError("Missing username in credentials.")

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -53,10 +53,14 @@ cred_group:
       description: "Password for network device"
       type: "string"
       secret: true
-      required: true
+      required: false
     secret:
       description: "Optional password for entering enable mode"
       type: "string"
       secret: true
+      required: false
+    key_file:
+      description: "Path to a private key file"
+      type: "string"
       required: false
   additionalProperties: false

--- a/napalm.yaml.example
+++ b/napalm.yaml.example
@@ -13,6 +13,10 @@ credentials:
     username: ciscouser
     password: ciscopw
     secret: ciscoenable
+  firewall:
+    username: junos
+    key_file: "/home/fwadmin/.ssh/id_rsa"
+
 
 devices:
 - hostname: router1.lon
@@ -27,3 +31,7 @@ devices:
   port: 22
   driver: ios
   credentials: access
+- hostname: fw1.syd
+  port: 22
+  driver: junos
+  credentials: firewall

--- a/pack.yaml
+++ b/pack.yaml
@@ -8,6 +8,6 @@ keywords:
     - juniper
     - arista
     - ibm
-version: 0.2.13
+version: 0.2.14
 author: mierdin, Rob Woodward
 email: info@stackstorm.com


### PR DESCRIPTION
Make `password` optional, and support `key_file` for SSH key-based authentication.

Resolves #50 