### PR TITLE
Remove napalm-ibm

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.3
+
+- Removed `napalm-ibm` as it is no longer maintained, and pins to an older version of paramiko that breaks other drivers.
+
 ## 0.2.16
 
 - Added "nxos_ssh" to supported Napalm drivers for legacy nx-os systems without NX-API support. (inline transfer only)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Change Log
 
-## 0.3
+## 0.3.0
 
 - Removed `napalm-ibm` as it is no longer maintained, and pins to an older version of paramiko that breaks other drivers.
 

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,6 @@ keywords:
     - cisco
     - juniper
     - arista
-    - ibm
-version: 0.2.16
+version: 0.3
 author: mierdin, Rob Woodward
 email: info@stackstorm.com

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
     - cisco
     - juniper
     - arista
-version: 0.3
+version: 0.3.0
 author: mierdin, Rob Woodward
 email: info@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 napalm-base
 napalm-eos
 napalm-fortios
-napalm-ibm
 napalm-ios
 napalm-iosxr
 napalm-junos


### PR DESCRIPTION
The napalm-ibm driver is no longer maintained, and it pins to an old paramiko version. This breaks other things, e.g. passphrase support. If napalm-ibm is not included by default, then newer versions of paramiko are installed.