### PR TITLE
Driver Reunification

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.4.0
+
+- Driver reunification - switched to just "napalm" import, removed device-specific and napalm-base
+
 ## 0.3.0
 
 - Removed `napalm-ibm` as it is no longer maintained, and pins to an older version of paramiko that breaks other drivers.

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,6 +7,6 @@ keywords:
     - cisco
     - juniper
     - arista
-version: 0.3.0
+version: 0.4.0
 author: mierdin, Rob Woodward
 email: info@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,3 @@
-napalm-base
-napalm-eos
-napalm-fortios
-napalm-ios
-napalm-iosxr
-napalm-junos
-napalm-nxos
-napalm-pluribus
-napalm-panos
 napalm
 json2table
 GitPython


### PR DESCRIPTION
Closes #26 

Remove older style napalm-base and driver-specific imports, only import napalm. 

See more about history at https://napalm-automation.net/reunification/