### PR TITLE
Restrict napalm to < 3.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.4.1
+
+- Restrict napalm dependency to < 3.0 to preserve Python 2.7 support
+
 ## 0.4.0
 
 - Driver reunification - switched to just "napalm" import, removed device-specific and napalm-base

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - cisco
   - juniper
   - arista
-version: 0.4.0
+version: 0.4.1
 author: mierdin, Rob Woodward
 email: info@stackstorm.com
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-napalm
+napalm<3.0
 json2table
 GitPython


### PR DESCRIPTION
The napalm package, and the netmiko package it depends on, both dropped support for Python 2.7 in their version 3.0.0 releases. This PR restricts the napalm dependency to < 3.0 to preserve Python 2.7 compatibility for this pack.

Fixes the weekend builds.