### PR TITLE
Clear and update apt cache during deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,7 @@ jobs:
           key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
           paths:
             - ~/.cache/pip
+            - ~/.apt-cache
       # NOTE: We use virtualenv files from Python 2.7 step in "deploy" job so we
       # only persist paths from this job
       - persist_to_workspace:
@@ -85,6 +86,7 @@ jobs:
           key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
           paths:
             - ~/.cache/pip
+            - ~/.apt-cache
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,9 +105,7 @@ jobs:
           at: /
       - run:
           name: Install dependencies
-          command: |
-            sudo apt-get update
-            sudo apt -y install gmic optipng
+          command: sudo apt -y install gmic optipng
       - run:
           name: Update exchange.stackstorm.org
           command:  ~/ci/.circle/deployment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,6 @@ jobs:
           key: v1-dependency-cache-py27-{{ checksum "requirements.txt" }}
           paths:
             - ~/.cache/pip
-            - ~/.apt-cache
       # NOTE: We use virtualenv files from Python 2.7 step in "deploy" job so we
       # only persist paths from this job
       - persist_to_workspace:
@@ -86,7 +85,6 @@ jobs:
           key: v1-dependency-cache-py36-{{ checksum "requirements.txt" }}
           paths:
             - ~/.cache/pip
-            - ~/.apt-cache
 
   deploy:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,14 +104,10 @@ jobs:
       - attach_workspace:
           at: /
       - run:
-          name: Clear apt cache
-          command: sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial
-      - run:
-          name: Update apt cache
-          command: sudo apt-get update
-      - run:
           name: Install dependencies
-          command: sudo apt -y install gmic optipng
+          command: |
+            sudo apt-get update
+            sudo apt -y install gmic optipng
       - run:
           name: Update exchange.stackstorm.org
           command:  ~/ci/.circle/deployment

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,12 @@ jobs:
       - attach_workspace:
           at: /
       - run:
+          name: Clear apt cache
+          command: sudo rm -rf /var/cache/apt/archives && sudo ln -s ~/.apt-cache /var/cache/apt/archives && mkdir -p ~/.apt-cache/partial
+      - run:
+          name: Update apt cache
+          command: sudo apt-get update
+      - run:
           name: Install dependencies
           command: sudo apt -y install gmic optipng
       - run:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+# Invalidate CircleCI cache: v2
 napalm<3.0
 json2table
 GitPython


### PR DESCRIPTION
Getting build failures during deploy: https://circleci.com/gh/StackStorm-Exchange/stackstorm-napalm/318

I'm not sure why our `deploy` phase workflow doesn't clear and update its apt cache, but it looks like we do that for all other workflows in the `.circle/dependencies` script: https://github.com/StackStorm-Exchange/ci/blob/master/.circle/dependencies#L27-L32

I copy/pasted the commands from that script into the workflow here to see if it is successful. If so, i'll replicate this PR for all other exchange packs.

