### PR TITLE
Add @floatingstatic as pack maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence, users and
+# teams which are put in owners will be requested for review
+# when someone opens a pull request.
+
+# This is base configuration. These owners could review the
+# whole file in this repository.
+* @StackStorm-Exchange/tsc @floatingstatic
+
+# CI configuration files should be reviewed by specific owners
+# who are more responsible for ensuring the quality of this pack
+# or orchestrate StackStorm-Exchanges.
+.circleci/**  @StackStorm-Exchange/tsc

--- a/README.md
+++ b/README.md
@@ -264,3 +264,7 @@ First, you'll need to install the virtualenv yourself:
 Also, you will need to manually register the pack if you make changes to its metadata or configuration:
 
   st2 pack register napalm
+
+## Maintainers
+Active pack maintainers with review & write repository access and expertise with NAPALM:
+* Jeremiah Millay ([@floatingstatic](https://github.com/floatingstatic)), Fastly


### PR DESCRIPTION
Following the https://github.com/StackStorm-Exchange/stackstorm-napalm/pull/67, add @floatingstatic as a Napalm pack maintainer who agreed in helping with the pack.

> Side note
Also Cross-linking StackStorm-Exchange/exchange-incubator#152 for including the Maintainers in the `.github/Codeowners`.
