### PR TITLE
Fix #69 wrong "LLDPNeighborIncrease" trigger name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.0.1
+
+- Fix `LLDPNeighborIncrease` trigger in LLDP sensor
+
 ## 1.0.0
 
 * Drop Python 2.7 support

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - cisco
   - juniper
   - arista
-version: 1.0.0
+version: 1.0.1
 author: mierdin, Rob Woodward
 email: info@stackstorm.com
 python_versions:

--- a/sensors/lldp_sensor.yaml
+++ b/sensors/lldp_sensor.yaml
@@ -6,7 +6,7 @@ enabled: false  # disabled by default; this is for demo purposes only.
 
 trigger_types:
 
-- name: "LLDPNeighborDecrease"
+- name: "LLDPNeighborIncrease"
   description: "Trigger which occurs when a device's LLDP neighbors increase"
   payload_schema:
     type: "object"


### PR DESCRIPTION
Fix #69
Tested in my vagrant environment.

Before
```
vagrant@st2vagrant:~$ sudo st2 trigger list --pack=napalm
+---------------------------+--------+---------------------------+
| ref                       | pack   | description               |
+---------------------------+--------+---------------------------+
| napalm.LLDPNeighborDecrea | napalm | Trigger which occurs when |
| se                        |        | a device's LLDP neighbors |
|                           |        | decrease                  |
+---------------------------+--------+---------------------------+
```

After
```
vagrant@st2vagrant:~$ sudo st2 trigger list --pack=napalm
+---------------------------+--------+---------------------------+
| ref                       | pack   | description               |
+---------------------------+--------+---------------------------+
| napalm.LLDPNeighborDecrea | napalm | Trigger which occurs when |
| se                        |        | a device's LLDP neighbors |
|                           |        | decrease                  |
| napalm.LLDPNeighborIncrea | napalm | Trigger which occurs when |
| se                        |        | a device's LLDP neighbors |
|                           |        | increase                  |
+---------------------------+--------+---------------------------+
```