### PR TITLE
Use napalm version 3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 
 ## 1.1.0
 
-- Update napalm dependency to > 3.0 to support Python 3.6+ only
+- Update napalm dependency to > 3.4 to support Python 3.6+ only
+- Fix issue #71
 
 ## 1.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.1.0
+
+- Update napalm dependency to > 3.0 to support Python 3.6+ only
+
 ## 1.0.1
 
 - Fix `LLDPNeighborIncrease` trigger in LLDP sensor

--- a/pack.yaml
+++ b/pack.yaml
@@ -7,7 +7,7 @@ keywords:
   - cisco
   - juniper
   - arista
-version: 1.0.2
+version: 1.1.0
 author: mierdin, Rob Woodward
 email: info@stackstorm.com
 python_versions:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-napalm<3.0
+napalm>3.4
 json2table
 GitPython
 # transitive deps: (napalm deps)


### PR DESCRIPTION
NAPALM version 3.0 and greater support Python >= 3.6+. As we have dropped support for Python2 and the last 3 releases of st2 all support Python 3.6, let's use NAPALM version 3 and greater going forward.

Tested pack actions work with the latest napalm release (version 3.3.1) using st2-docker versions 3.3, 3.4 and 3.5.
